### PR TITLE
Add option mapCommentType to fix CSS source maps.

### DIFF
--- a/lib/source-map.js
+++ b/lib/source-map.js
@@ -22,6 +22,7 @@ function SourceMap(opts) {
   this.cache = opts.cache;
   this.mapFile = opts.mapFile || this.outputFile.replace(/\.js$/, '') + '.map';
   this.mapURL = opts.mapURL || path.basename(this.mapFile);
+	this.mapCommentType = opts.mapCommentType || 'line';
   this._initializeStream();
 
   this.content = {
@@ -336,7 +337,11 @@ SourceMap.prototype._scanMappings = function(srcMap, sourcesOffset, namesOffset,
 };
 
 SourceMap.prototype.end = function() {
-  this.stream.write('//# sourceMappingURL=' + this.mapURL);
+	if (this.mapCommentType === 'line') {
+		this.stream.write('//# sourceMappingURL=' + this.mapURL);
+	} else {
+		this.stream.write('/*# sourceMappingURL=' + this.mapURL + ' */');
+	}
   mkdirp.sync(path.dirname(this.mapFile));
   fs.writeFileSync(this.mapFile, JSON.stringify(this.content));
   return new RSVP.Promise(function(resolve, reject) {

--- a/lib/source-map.js
+++ b/lib/source-map.js
@@ -22,7 +22,7 @@ function SourceMap(opts) {
   this.cache = opts.cache;
   this.mapFile = opts.mapFile || this.outputFile.replace(/\.js$/, '') + '.map';
   this.mapURL = opts.mapURL || path.basename(this.mapFile);
-	this.mapCommentType = opts.mapCommentType || 'line';
+  this.mapCommentType = opts.mapCommentType || 'line';
   this._initializeStream();
 
   this.content = {
@@ -337,11 +337,11 @@ SourceMap.prototype._scanMappings = function(srcMap, sourcesOffset, namesOffset,
 };
 
 SourceMap.prototype.end = function() {
-	if (this.mapCommentType === 'line') {
-		this.stream.write('//# sourceMappingURL=' + this.mapURL);
-	} else {
-		this.stream.write('/*# sourceMappingURL=' + this.mapURL + ' */');
-	}
+  if (this.mapCommentType === 'line') {
+    this.stream.write('//# sourceMappingURL=' + this.mapURL);
+  } else {
+    this.stream.write('/*# sourceMappingURL=' + this.mapURL + ' */');
+  }
   mkdirp.sync(path.dirname(this.mapFile));
   fs.writeFileSync(this.mapFile, JSON.stringify(this.content));
   return new RSVP.Promise(function(resolve, reject) {

--- a/test/test.js
+++ b/test/test.js
@@ -145,14 +145,14 @@ describe('fast sourcemap concat', function() {
     });
   });
 
-	it("outputs block comments when 'mapCommentType' is 'block'", function() {
-		var FILE = 'tmp/mapcommenttype.css';
-		var s = new SourceMap({outputFile: FILE, mapCommentType: 'block'});
-		return s.end().then(function() {
-			var result = fs.readFileSync(FILE, 'utf-8');
-			assert.equal(result, "/*# sourceMappingURL=mapcommenttype.css.map */");
-		});
-	});
+  it("outputs block comments when 'mapCommentType' is 'block'", function() {
+    var FILE = 'tmp/mapcommenttype.css';
+    var s = new SourceMap({outputFile: FILE, mapCommentType: 'block'});
+    return s.end().then(function() {
+      var result = fs.readFileSync(FILE, 'utf-8');
+      assert.equal(result, "/*# sourceMappingURL=mapcommenttype.css.map */");
+    });
+  });
 
 });
 

--- a/test/test.js
+++ b/test/test.js
@@ -145,6 +145,15 @@ describe('fast sourcemap concat', function() {
     });
   });
 
+	it("outputs block comments when 'mapCommentType' is 'block'", function() {
+		var FILE = 'tmp/mapcommenttype.css';
+		var s = new SourceMap({outputFile: FILE, mapCommentType: 'block'});
+		return s.end().then(function() {
+			var result = fs.readFileSync(FILE, 'utf-8');
+			assert.equal(result, "/*# sourceMappingURL=mapcommenttype.css.map */");
+		});
+	});
+
 });
 
 function expectFile(filename) {


### PR DESCRIPTION
CSS doesn't support line comments, so block comment must be used when concatenating CSS files.

I added option `mapCommentType` with possible values `line` and `block`, and default value `line`.