### PR TITLE
Allow adding file contents without writing to disk.

### DIFF
--- a/lib/source-map.js
+++ b/lib/source-map.js
@@ -64,8 +64,13 @@ SourceMap.prototype._initializeStream = function() {
 
 
 SourceMap.prototype.addFile = function(filename) {
-  var url;
   var source = fs.readFileSync(this._resolveFile(filename), 'utf-8');
+
+  return this.addFileSource(filename, source);
+};
+
+SourceMap.prototype.addFileSource = function(filename, source) {
+  var url;
   var inputSrcMap;
 
   if (source.length === 0) {

--- a/test/test.js
+++ b/test/test.js
@@ -58,6 +58,23 @@ describe('fast sourcemap concat', function() {
     });
   });
 
+  it("should allow adding file contents from string", function() {
+    var filePath = 'fixtures/other/third.js';
+    var contents = fs.readFileSync(filePath, { encoding: 'utf8' });
+
+    var s = new SourceMap({outputFile: 'tmp/from-inline.js'});
+    s.addFileSource('fixtures/other/third.js', contents);
+    s.addSpace("/* My First Separator */");
+    s.addFile('fixtures/inline-mapped.js');
+    s.addSpace("/* My Second */");
+    s.addFile('fixtures/other/fourth.js');
+
+    return s.end().then(function(){
+      expectFile('from-inline.js').in('tmp');
+      expectFile('from-inline.map').in('tmp');
+    });
+  });
+
   it("should correctly concatenate a sourcemapped coffeescript example", function() {
     var s = new SourceMap({outputFile: 'tmp/coffee-example.js'});
     s.addFile('fixtures/coffee/aa-loader.js');


### PR DESCRIPTION
This will allow easier processing of sourcemaps during certain transpilation steps where you would not want to write to disk for the interim step (post transpilation but pre concat).