### PR TITLE
Data URI can contain semicolon's before `;base64,`.

### DIFF
--- a/lib/source-map.js
+++ b/lib/source-map.js
@@ -185,7 +185,7 @@ SourceMap.prototype._generateNewMap = function(source) {
 
 SourceMap.prototype._resolveSourcemap = function(filename, url) {
   var srcMap;
-  var match = /^data:[^;]+;base64,/.exec(url);
+  var match = /^data:.+;base64,/.exec(url);
 
   try {
     if (match) {


### PR DESCRIPTION
Per the spec, a Data URI is as follows:

```
dataurl    := "data:" [ mediatype ] [ ";base64" ] "," data
mediatype  := [ type "/" subtype ] *( ";" parameter )
data       := *urlchar
parameter  := attribute "=" value
```

Specifically, using esperanto to transpile with inline sourcemaps generates a data UI of:

```
//# sourceMappingURL=data:application/json;charset=utf-8;base64,
```

References:

* http://tools.ietf.org/html/rfc2397
* https://developer.mozilla.org/en-US/docs/Web/HTTP/data_URIs

---

I am unsure how exactly to add a test for this...