### PR TITLE
use character codes for detecting line endings instead of a regex

### DIFF
--- a/lib/source-map.js
+++ b/lib/source-map.js
@@ -370,10 +370,17 @@ SourceMap.prototype._warn = function(msg) {
 };
 
 function countNewLines(src) {
-  var newlinePattern = /(\r?\n)/g;
+  // Newline character for charCodeAt comparisons. This catches
+  // more things than \r or \n, such as \f (form feed).
+  // Taken from Mozilla's generator: https://github.com/mozilla/source-map/pull/152/files
+  var NEWLINE_CODE = 10;
   var count = 0;
-  while (newlinePattern.exec(src)) {
-    count++;
+  var length = src.length;
+
+  for (var i = 0; i < length; i++) {
+    if (src.charCodeAt(i) === NEWLINE_CODE) {
+      count++;
+    }
   }
   return count;
 }


### PR DESCRIPTION
Previously, when minifiying libraries such as es5-shim's es5-shim.min.js
which contained alternate line breaks (such as form feeds), the line
count was incorrect leading to negative line numbers when interopting
with tools like the Mozilla SourceMap generator.

I discovered this bug when working on ember-cli-uglify, which uses
UglifyJS, which in turn uses the Mozilla SourceMap generator which
used its own file count mechanism. I copied their file count mechanism
into here.

refs https://github.com/ember-cli/ember-cli-uglify/issues/4