### PR TITLE
Update to source-map@^0.4.2 and adjust lib/coder.js

### DIFF
--- a/lib/coder.js
+++ b/lib/coder.js
@@ -49,11 +49,11 @@ Coder.prototype.adjustLine = function(n) {
 };
 
 Coder.prototype.rawDecode = function(mapping) {
-  var buf = {rest: mapping};
+  var buf = {rest: 0};
   var output = {};
   var fieldIndex = 0;
-  while (fieldIndex < fields.length && buf.rest.length > 0) {
-    vlq.decode(buf.rest, buf);
+  while (fieldIndex < fields.length && buf.rest < mapping.length) {
+    vlq.decode(mapping, buf.rest, buf);
     output[fields[fieldIndex]] = buf.value;
     fieldIndex++;
   }
@@ -97,11 +97,11 @@ Coder.prototype._combine = function(other, operation) {
 };
 
 Coder.prototype.debug = function(mapping) {
-  var buf = {rest: mapping};
+  var buf = {rest: 0};
   var output = [];
   var fieldIndex = 0;
-  while (fieldIndex < fields.length && buf.rest.length > 0) {
-    vlq.decode(buf.rest, buf);
+  while (fieldIndex < fields.length && buf.rest < mapping.length) {
+    vlq.decode(mapping, buf.rest, buf);
     output.push(buf.value);
     fieldIndex++;
   }

--- a/lib/source-map.js
+++ b/lib/source-map.js
@@ -9,7 +9,7 @@ var chalk = require('chalk');
 
 module.exports = SourceMap;
 function SourceMap(opts) {
-  if (!this instanceof SourceMap) {
+  if (!(this instanceof SourceMap)) {
     return new SourceMap(opts);
   }
   if (!opts || !opts.outputFile) {
@@ -331,7 +331,7 @@ SourceMap.prototype._scanMappings = function(srcMap, sourcesOffset, namesOffset,
       }
 
 
-      if (match = continuation.exec(inputMappings)) {
+      if ((match = continuation.exec(inputMappings))) {
         // This is a significant optimization, especially when we're
         // doing simple line-for-line concatenations.
         lines = match[2].length / 5;

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "chalk": "^0.5.1",
     "mkdirp": "^0.5.0",
     "rsvp": "^3.0.14",
-    "source-map": "^0.1.40",
+    "source-map": "^0.4.2",
     "source-map-url": "^0.3.0"
   },
   "devDependencies": {


### PR DESCRIPTION
source-map@0.4.0 [introduced](https://github.com/mozilla/source-map/commit/2a04b71e0439f5febc8c66eeac0cfd74e4e6f2b1#diff-b566273fec9dae2c8af0da347a9cb6df) a more slightly more efficient `base64-vlq.js`.