### PR TITLE
Only hash the source if there is a cache

### DIFF
--- a/lib/source-map.js
+++ b/lib/source-map.js
@@ -99,11 +99,6 @@ SourceMap.prototype.addFileSource = function(filename, source) {
 };
 
 SourceMap.prototype._cacheEncoderResults = function(key, operations) {
-  if (!this.cache) {
-    operations.call(this);
-    return;
-  }
-
   var encoderState = this.encoder.copy();
   var initialLinesMapped = this.linesMapped;
   var cacheEntry = this.cache[key];
@@ -211,9 +206,13 @@ SourceMap.prototype._addMap = function(filename, srcMap, source) {
   var haveLines = countNewLines(source);
   var self = this;
 
-  this._cacheEncoderResults(hash(source), function(cacheHint){
-    self._assimilateExistingMap(filename, srcMap, cacheHint);
-  });
+  if (this.cache) {
+    this._cacheEncoderResults(hash(source), function(cacheHint) {
+      self._assimilateExistingMap(filename, srcMap, cacheHint);
+    });
+  } else {
+    this._assimilateExistingMap(filename, srcMap);
+  }
 
   while (this.linesMapped - initialLinesMapped < haveLines) {
     // This cleans up after upstream sourcemaps that are too short


### PR DESCRIPTION
Tiny optimization. Skip hashing the source when there isn't a cache, and jump straight to `_assimilateExistingMap`.