### PR TITLE
fix absolute path break on windows

### DIFF
--- a/lib/source-map.js
+++ b/lib/source-map.js
@@ -260,7 +260,7 @@ SourceMap.prototype._resolveSourcesContent = function(srcMap, filename) {
     // Look for original sources relative to our input source filename.
     return srcMap.sources.map(function(source){
       var fullPath;
-      if (source.slice(0, 1) === '/') {
+      if (path.isAbsolute(source)) {
         fullPath = source;
       } else {
         fullPath = path.join(path.dirname(this._resolveFile(filename)), source);


### PR DESCRIPTION
try to resolve path broken like "C:/wokdir/ember-proj/C:/wokdir/ember-proj/abc.less".

if (source.slice(0, 1) === '/') { not work
couse of absolute path start with "C:" | "D:" on windows.
