### PR TITLE
Implement support for in-memory concatenation without sync file writing.

### DIFF
--- a/lib/source-map.js
+++ b/lib/source-map.js
@@ -3,6 +3,7 @@ var srcURL = require('source-map-url');
 var path = require('path');
 var RSVP = require('rsvp');
 var mkdirp = require('mkdirp');
+var MemoryStreams = require('memory-streams');
 var Coder = require('./coder');
 var crypto = require('crypto');
 var chalk = require('chalk');
@@ -14,8 +15,8 @@ function SourceMap(opts) {
   if (!(this instanceof SourceMap)) {
     return new SourceMap(opts);
   }
-  if (!opts || !opts.outputFile) {
-    throw new Error("Must specify outputFile");
+  if (!opts || (!opts.outputFile && (!opts.mapURL || !opts.file))) {
+    throw new Error("Must specify at least outputFile or mapURL and file");
   }
   if (opts.mapFile && !opts.mapURL) {
     throw new Error("must specify the mapURL when setting a custom mapFile");
@@ -24,8 +25,8 @@ function SourceMap(opts) {
   this.baseDir = opts.baseDir;
   this.outputFile = opts.outputFile;
   this.cache = opts.cache;
-  this.mapFile = opts.mapFile || this.outputFile.replace(/\.js$/, '') + '.map';
-  this.mapURL = opts.mapURL || path.basename(this.mapFile);
+  this.mapFile = opts.mapFile || (this.outputFile && this.outputFile.replace(/\.js$/, '') + '.map');
+  this.mapURL = opts.mapURL || (this.mapFile && path.basename(this.mapFile));
   this.mapCommentType = opts.mapCommentType || 'line';
   this._initializeStream();
 
@@ -60,8 +61,12 @@ SourceMap.prototype._resolveFile = function(filename) {
 };
 
 SourceMap.prototype._initializeStream = function() {
-  mkdirp.sync(path.dirname(this.outputFile));
-  this.stream = fs.createWriteStream(this.outputFile);
+  if (this.outputFile) {
+    mkdirp.sync(path.dirname(this.outputFile));
+    this.stream = fs.createWriteStream(this.outputFile);
+  } else {
+    this.stream = new MemoryStreams.WritableStream();
+  }
 };
 
 
@@ -388,21 +393,30 @@ SourceMap.prototype.end = function(cb, thisArg) {
         stream.write('/*# sourceMappingURL=' + sourceMap.mapURL + ' */');
       }
 
-      mkdirp.sync(path.dirname(sourceMap.mapFile));
-      fs.writeFileSync(sourceMap.mapFile, JSON.stringify(sourceMap.content));
+      if (sourceMap.mapFile) {
+        mkdirp.sync(path.dirname(sourceMap.mapFile));
+        fs.writeFileSync(sourceMap.mapFile, JSON.stringify(sourceMap.content));
+      }
       success = true;
     } catch(e) {
       success = false;
       error = e;
     } finally {
-      stream.on('close', function() {
-        if (success) {
-          resolve();
-        } else {
-          reject(error);
-        }
-      });
-      stream.end();
+      if (sourceMap.outputFile) {
+        stream.on('close', function() {
+          if (success) {
+            resolve();
+          } else {
+            reject(error);
+          }
+        });
+        stream.end();
+      } else {
+        resolve({
+          code: stream.toString(),
+          map: sourceMap.content
+        });
+      }
     }
   });
 };

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
   "dependencies": {
     "chalk": "^0.5.1",
     "debug": "^2.2.0",
+    "memory-streams": "^0.1.0",
     "mkdirp": "^0.5.0",
     "rsvp": "^3.0.14",
     "source-map": "^0.4.2",

--- a/test/test.js
+++ b/test/test.js
@@ -47,6 +47,21 @@ describe('fast sourcemap concat', function() {
     });
   });
 
+  it("should support file-less concatenation", function() {
+    var s = new SourceMap({file: 'from-inline.js', mapURL: 'from-inline.map'});
+    s.addFile('fixtures/other/third.js');
+    s.addSpace("/* My First Separator */");
+    s.addFile('fixtures/inline-mapped.js');
+    s.addSpace("/* My Second */");
+    s.addFile('fixtures/other/fourth.js');
+    return s.end().then(function(r){
+      expect(r).to.be.a('object');
+      expect(r.map).to.be.a('object');
+      expectFile('from-inline.js', r.code || "empty").in('tmp');
+      expectFile('from-inline.map', JSON.stringify(r.map) || "empty").in('tmp');
+    });
+  });
+
   it("should accept inline sourcemaps", function() {
     var s = new SourceMap({outputFile: 'tmp/from-inline.js'});
     s.addFile('fixtures/other/third.js');
@@ -289,11 +304,11 @@ describe('fast sourcemap concat', function() {
   });
 });
 
-function expectFile(filename) {
+function expectFile(filename, actualContent) {
   var stripURL = false;
   return {
     in: function(dir) {
-      var actualContent = ensurePosix(fs.readFileSync(path.join(dir, filename), 'utf-8'));
+      actualContent = actualContent || ensurePosix(fs.readFileSync(path.join(dir, filename), 'utf-8'));
       fs.writeFileSync(path.join(__dirname, 'actual', filename), actualContent);
 
       var expectedContent;


### PR DESCRIPTION
- file+mapURL is used instead of outputFile for file-less mode
- Code is written to a writable memory stream
- A {code: "...", map: {...}} object is returned from the promise when file-less mode is used