### PR TITLE
process.env.CONCAT_STATS enables debug output

### DIFF
--- a/lib/source-map.js
+++ b/lib/source-map.js
@@ -369,6 +369,7 @@ SourceMap.prototype._scanMappings = function(srcMap, sourcesOffset, namesOffset,
 };
 
 SourceMap.prototype.writeConcatStatsSync = function(outputPath, content) {
+  fs.mkdirpSync(path.basename(outputPath));
   fs.writeFileSync(outputPath, JSON.stringify(content, null, 2));
 };
 
@@ -393,7 +394,7 @@ SourceMap.prototype.end = function(cb, thisArg) {
       }
 
       if (process.env.CONCAT_STATS) {
-        var outputPath = process.cwd() + '/concat-stats-for-' + sourceMap.id + '-' + path.basename(sourceMap.outputFile) + '.json';
+        var outputPath = process.cwd() + '/concat-stats-for/' + sourceMap.id + '-' + path.basename(sourceMap.outputFile) + '.json';
 
         sourceMap.writeConcatStatsSync(
           outputPath,
@@ -439,7 +440,6 @@ SourceMap.prototype.end = function(cb, thisArg) {
 };
 
 SourceMap.prototype._warn = function(msg) {
-
   console.log(chalk.yellow(msg));
 };
 

--- a/lib/source-map.js
+++ b/lib/source-map.js
@@ -52,6 +52,7 @@ function SourceMap(opts) {
   // the concatenated sourcemap. We use this to correct broken input
   // sourcemaps that don't match the length of their sourcecode.
   this.linesMapped = 0;
+  this._sizes = {};
 }
 SourceMap.prototype._resolveFile = function(filename) {
   if (this.baseDir && filename.slice(0,1) !== '/') {
@@ -72,6 +73,7 @@ SourceMap.prototype._initializeStream = function() {
 
 SourceMap.prototype.addFile = function(filename) {
   var source = ensurePosix(fs.readFileSync(this._resolveFile(filename), 'utf-8'));
+  this._sizes[filename] = source.length;
   return this.addFileSource(filename, source);
 };
 
@@ -366,10 +368,13 @@ SourceMap.prototype._scanMappings = function(srcMap, sourcesOffset, namesOffset,
   this.content.mappings = mappings;
 };
 
+SourceMap.prototype.writeConcatStatsSync = function(outputPath, content) {
+  fs.writeFileSync(outputPath, JSON.stringify(content, null, 2));
+};
+
 SourceMap.prototype.end = function(cb, thisArg) {
   var stream = this.stream;
   var sourceMap = this;
-
 
   return new RSVP.Promise(function(resolve, reject) {
     stream.on('error', function(error) {
@@ -385,6 +390,18 @@ SourceMap.prototype.end = function(cb, thisArg) {
     try {
       if (cb) {
         cb.call(thisArg, sourceMap);
+      }
+
+      if (process.env.CONCAT_STATS) {
+        var outputPath = process.cwd() + '/concat-stats-for-' + sourceMap.id + '-' + path.basename(sourceMap.outputFile) + '.json';
+
+        sourceMap.writeConcatStatsSync(
+          outputPath,
+          {
+            outputFile: sourceMap.outputFile,
+            sizes: sourceMap._sizes
+          }
+        );
       }
 
       if (sourceMap.mapCommentType === 'line') {

--- a/package.json
+++ b/package.json
@@ -4,7 +4,8 @@
   "description": "Concatenate files while generating or propagating sourcemaps.",
   "main": "lib/index.js",
   "scripts": {
-    "test": "mocha --inline-diffs"
+    "test": "mocha --inline-diffs",
+    "test:debug": "mocha --no-timeouts debug"
   },
   "files": [
     "lib"

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
   "dependencies": {
     "chalk": "^0.5.1",
     "debug": "^2.2.0",
+    "fs-extra": "^0.30.0",
     "memory-streams": "^0.1.0",
     "mkdirp": "^0.5.0",
     "rsvp": "^3.0.14",

--- a/test/test.js
+++ b/test/test.js
@@ -337,7 +337,7 @@ describe('fast sourcemap concat', function() {
       return concat.end().then(function() {
         expect(outputs.length).to.eql(1);
 
-        var outputPath = process.cwd() + '/concat-stats-for-' + concat.id + '-' + path.basename(concat.outputFile) + '.json';
+        var outputPath = process.cwd() + '/concat-stats-for/' + concat.id + '-' + path.basename(concat.outputFile) + '.json';
         expect(outputs[0].outputPath).to.eql(outputPath);
         expect(outputs[0].content).to.eql({
           outputFile: concat.outputFile,

--- a/test/test.js
+++ b/test/test.js
@@ -302,6 +302,66 @@ describe('fast sourcemap concat', function() {
       expectFile('hello-world-output-2.map').in('tmp');
     });
   });
+
+  describe('CONCAT_STATS', function() {
+    var outputs;
+    var concat;
+
+    beforeEach(function() {
+      process.env.CONCAT_STATS = true;
+      outputs = [];
+
+      concat = new SourceMap({
+        outputFile: 'tmp/hello-world-output.js',
+        cache: {}
+      });
+
+      concat.writeConcatStatsSync = function(outputPath, content) {
+        outputs.push({
+          outputPath: outputPath,
+          content: content
+        });
+      };
+    });
+
+    afterEach(function() {
+      delete process.env.CONCAT_STATS;
+    });
+
+    it('correctly emits file for given concat', function() {
+      concat.addFile('fixtures/inner/second.js');
+      concat.addFile('fixtures/inner/first.js');
+
+      expect(outputs.length).to.eql(0);
+
+      return concat.end().then(function() {
+        expect(outputs.length).to.eql(1);
+
+        var outputPath = process.cwd() + '/concat-stats-for-' + concat.id + '-' + path.basename(concat.outputFile) + '.json';
+        expect(outputs[0].outputPath).to.eql(outputPath);
+        expect(outputs[0].content).to.eql({
+          outputFile: concat.outputFile,
+          sizes: {
+            'fixtures/inner/first.js': 100,
+            'fixtures/inner/second.js': 66
+          }
+        });
+      });
+    });
+
+    it('correctly DOES NOT emits file for given concat, if the flag is not set', function() {
+      delete process.env.CONCAT_STATS;
+
+      concat.addFile('fixtures/inner/second.js');
+      concat.addFile('fixtures/inner/first.js');
+
+      expect(outputs.length).to.eql(0);
+
+      return concat.end().then(function() {
+        expect(outputs.length).to.eql(0);
+      });
+    })
+  });
 });
 
 function expectFile(filename, actualContent) {


### PR DESCRIPTION
This output is written to disk at cwd +
concat-stats-for-<name-of-outputfile>.json and contains the sizes of the
various pieces the outputfile is made of.

This aims to enable improved debuggability / visibility of large output
assets.