### PR TITLE
Missing source file can cause a crash

### DIFF
--- a/lib/source-map.js
+++ b/lib/source-map.js
@@ -72,9 +72,13 @@ SourceMap.prototype._initializeStream = function() {
 
 
 SourceMap.prototype.addFile = function(filename) {
-  var source = ensurePosix(fs.readFileSync(this._resolveFile(filename), 'utf-8'));
-  this._sizes[filename] = source.length;
-  return this.addFileSource(filename, source);
+  try {
+    var source = ensurePosix(fs.readFileSync(this._resolveFile(filename), 'utf-8'));
+    this._sizes[filename] = source.length;
+    return this.addFileSource(filename, source);
+  } catch (err) {    
+    this._warn('Warning: ignoring input sourcemap for ' + filename + ' because ' + err.message);
+  }
 };
 
 SourceMap.prototype.addFileSource = function(filename, source, inputSrcMap) {

--- a/test/test.js
+++ b/test/test.js
@@ -46,6 +46,15 @@ describe('fast sourcemap concat', function() {
       expectFile('final.map').in('tmp');
     });
   });
+  
+  it("should not crash if a file is not found", function() {
+    var s = new SourceMap({outputFile: 'tmp/bogus.js'});
+    s.addFile('this_is_a_totally_bogus_file_name.js');
+    
+    return s.end().then(function(){
+      expectFile('bogus.map').in('tmp');
+    }
+  });
 
   it("should support file-less concatenation", function() {
     var s = new SourceMap({file: 'from-inline.js', mapURL: 'from-inline.map'});

--- a/test/test.js
+++ b/test/test.js
@@ -49,9 +49,12 @@ describe('fast sourcemap concat', function() {
   
   it("should not crash if a file is not found", function() {
     var s = new SourceMap({outputFile: 'tmp/bogus.js'});
+    var filler = "'x';";
+    s.addSpace(filler);
     s.addFile('this_is_a_totally_bogus_file_name.js');
     
     return s.end().then(function(){
+      expectFile('bogus.js').in('tmp');
       expectFile('bogus.map').in('tmp');
     });
   });

--- a/test/test.js
+++ b/test/test.js
@@ -53,7 +53,7 @@ describe('fast sourcemap concat', function() {
     
     return s.end().then(function(){
       expectFile('bogus.map').in('tmp');
-    }
+    });
   });
 
   it("should support file-less concatenation", function() {

--- a/test/test.js
+++ b/test/test.js
@@ -49,14 +49,9 @@ describe('fast sourcemap concat', function() {
   
   it("should not crash if a file is not found", function() {
     var s = new SourceMap({outputFile: 'tmp/bogus.js'});
-    var filler = "'x';";
-    s.addSpace(filler);
     s.addFile('this_is_a_totally_bogus_file_name.js');
     
-    return s.end().then(function(){
-      expectFile('bogus.js').in('tmp');
-      expectFile('bogus.map').in('tmp');
-    });
+    return s.end()
   });
 
   it("should support file-less concatenation", function() {


### PR DESCRIPTION
Encountered via Broccoli-concat and an ignored bower dependency.