### PR TITLE
Use console.warn for warnings

### DIFF
--- a/lib/source-map.js
+++ b/lib/source-map.js
@@ -446,7 +446,7 @@ SourceMap.prototype.end = function(cb, thisArg) {
 };
 
 SourceMap.prototype._warn = function(msg) {
-  console.log(chalk.yellow(msg));
+  console.warn(chalk.yellow(msg));
 };
 
 function countNewLines(src) {


### PR DESCRIPTION
Due to [missing sourcemaps in Ember 2.14](https://github.com/emberjs/ember.js/issues/15464), the warnings emitted by this package were invalidating the XML output of the tests of our Ember app, as per #35. I didn't see any obvious way to access ember-cli's `ui` object from within this package, however, and so I would suggest this workaround. By using `console.warn` in place of `console.log` for warnings, stdout and stderr could be redirected separately, restoring the ability of our CI to run the tests via something like `ember t --silent --r xunit 2> /dev/null > TEST_OUTPUT.xml`.