### PR TITLE
Move heimdalljs-logger to dependencies.

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
   "dependencies": {
     "chalk": "^0.5.1",
     "fs-extra": "^0.30.0",
+    "heimdalljs-logger": "^0.1.7",
     "memory-streams": "^0.1.0",
     "mkdirp": "^0.5.0",
     "rsvp": "^3.0.14",
@@ -25,7 +26,6 @@
   },
   "devDependencies": {
     "chai": "^1.10.0",
-    "heimdalljs-logger": "^0.1.7",
     "mocha": "^2.0.1",
     "mocha-jshint": "0.0.9",
     "rimraf": "^2.2.8",


### PR DESCRIPTION
Had been `devDependencies` only. See comments at https://github.com/ef4/fast-sourcemap-concat/commit/5e0b416bf91a2a18972b0ed3d05e2381ab3a4969 .