### PR TITLE
Don't prepend baseDir to filename if it's already a full path on Windows

### DIFF
--- a/lib/source-map.js
+++ b/lib/source-map.js
@@ -54,7 +54,7 @@ class SourceMap {
   }
 
   _resolveFile(filename) {
-    if (this.baseDir && filename.slice(0,1) !== '/' && filename.slice(1, 2) !== ':') {
+    if (this.baseDir && !path.isAbsolute(filename)) {
       filename = path.join(this.baseDir, filename);
     }
     return filename;

--- a/lib/source-map.js
+++ b/lib/source-map.js
@@ -54,7 +54,7 @@ class SourceMap {
   }
 
   _resolveFile(filename) {
-    if (this.baseDir && filename.slice(0,1) !== '/') {
+    if (this.baseDir && filename.slice(0,1) !== '/' && filename.slice(1, 2) !== ':') {
       filename = path.join(this.baseDir, filename);
     }
     return filename;


### PR DESCRIPTION
On Windows, sometimes `_resolveFile()` can receive a full path instead of a filename, which breaks the build. This guards against prepending the baseDir to the filename again, if it's already a full path with a drive letter and ':' in it.