### PR TITLE
Perform faster string termination check.

### DIFF
--- a/lib/source-map.js
+++ b/lib/source-map.js
@@ -88,7 +88,12 @@ class SourceMap {
       source = srcURL.removeFrom(source);
     }
 
-    if (this.content.mappings.length > 0 && !/[;,]$/.test(this.content.mappings)) {
+    const endingCharacters = {
+      ',': true,
+      ';': true,
+    };
+
+    if (this.content.mappings.length > 0 && !endingCharacters[this.content.mappings[this.content.mappings.length - 1]]) {
       this.content.mappings += ',';
     }
 


### PR DESCRIPTION
I noticed in a project of mine that the regex.test call was taking up to 20% of
my applications CPU time. I did some quick testing and came up with this check
which is ~20-100x faster depending on the input.

Profile before the change:
![image](https://user-images.githubusercontent.com/4172067/36829594-b719226e-1cd4-11e8-94dd-f8c49222f004.png)

I didn't take another profile, but I did log some timings with this snippet.
```js
console.time('ifcheck');
var should = this.content.mappings.length > 0 && !/[;,]$/.test(this.content.mappings);
console.timeEnd('ifcheck');
var endingCharacters = {
  ',': true,
  ';': true,
}
console.time('endcheck');
var should2 = this.content.mappings.length > 0 && !endingCharacters[this.content.mappings[this.content.mappings.length - 1]];
console.timeEnd('endcheck');
if (should !== should2) {
  throw new Error('No Match!');
}
```

The result:
```
ifcheck: 0.238ms
endcheck: 0.042ms
ifcheck: 2.000ms
endcheck: 0.052ms
ifcheck: 2.761ms
endcheck: 0.029ms
ifcheck: 0.129ms
endcheck: 0.023ms
ifcheck: 0.096ms
endcheck: 0.023ms
ifcheck: 0.094ms
endcheck: 0.023ms
ifcheck: 2.101ms
endcheck: 0.064ms
ifcheck: 0.256ms
endcheck: 0.091ms
```

Feel free to update my PR if you need any changes!