### PR TITLE
[Performance] Speed up concatenation by tracking the end of content.mappings.

### DIFF
--- a/lib/endsWith.js
+++ b/lib/endsWith.js
@@ -1,0 +1,3 @@
+module.exports = function endsWith(aString, target) {
+  return aString.endsWith(target);
+};

--- a/lib/source-map.js
+++ b/lib/source-map.js
@@ -8,8 +8,10 @@ const Coder = require('./coder');
 const crypto = require('crypto');
 const chalk = require('chalk');
 const EOL = require('os').EOL;
+const endsWith = require('./endsWith');
 const validator = require('sourcemap-validator');
 const logger = require('heimdalljs-logger')('fast-sourcemap-concat:');
+
 
 class SourceMap {
   constructor(opts) {
@@ -51,6 +53,7 @@ class SourceMap {
     // sourcemaps that don't match the length of their sourcecode.
     this.linesMapped = 0;
     this._sizes = {};
+    this.nextFileSourceNeedsComma = false;
   }
 
   _resolveFile(filename) {
@@ -88,8 +91,9 @@ class SourceMap {
       source = srcURL.removeFrom(source);
     }
 
-    if (this.content.mappings.length > 0 && !/[;,]$/.test(this.content.mappings)) {
+    if (this.content.mappings.length > 0 && this.nextFileSourceNeedsComma) {
       this.content.mappings += ',';
+      this.nextFileSourceNeedsComma = false;
     }
 
     if (typeof inputSrcMap === 'string') {
@@ -177,6 +181,7 @@ class SourceMap {
       let mappings = this.content.mappings;
       for (let i = 0; i < lineCount; i++) {
         mappings += ';';
+        this.nextFileSourceNeedsComma = false;
       }
       this.content.mappings = mappings;
     }
@@ -185,13 +190,15 @@ class SourceMap {
   _generateNewMap(source) {
     let mappings = this.content.mappings;
     let lineCount = countNewLines(source);
-
-    mappings += this.encoder.encode({
+    const encodedVal = this.encoder.encode({
       generatedColumn: this.column,
       source: this.content.sources.length-1,
       originalLine: 0,
       originalColumn: 0
     });
+
+    mappings += encodedVal;
+    this.nextFileSourceNeedsComma = !(endsWith(encodedVal, ';') || endsWith(encodedVal, ','));
 
     if (lineCount === 0) {
       // no newline in the source. Keep outputting one big line.
@@ -201,6 +208,7 @@ class SourceMap {
       this.column = 0;
       this.encoder.resetColumn();
       mappings += ';';
+      this.nextFileSourceNeedsComma = false;
       this.encoder.adjustLine(lineCount-1);
     }
 
@@ -208,6 +216,7 @@ class SourceMap {
     // one-to-one.
     for (let i = 0; i < lineCount-1; i++) {
       mappings += 'AACA;';
+      this.nextFileSourceNeedsComma = false;
     }
     this.linesMapped += lineCount;
     this.content.mappings = mappings;
@@ -255,6 +264,7 @@ class SourceMap {
       // for their sourcecode so they don't break the rest of our
       // mapping. Coffeescript does this.
       this.content.mappings += ';';
+      this.nextFileSourceNeedsComma = false;
       this.linesMapped++;
     }
     while (haveLines < this.linesMapped - initialLinesMapped) {
@@ -328,6 +338,7 @@ class SourceMap {
       // If the entry was preceded by separators, copy them through.
       if (match[1]) {
         mappings += match[1];
+        this.nextFileSourceNeedsComma = !(endsWith(match[1], ',') || endsWith(match[1], ';'));
         lines = match[1].replace(/,/g, '').length;
         if (lines > 0) {
           this.linesMapped += lines;
@@ -351,7 +362,9 @@ class SourceMap {
           decoder.prev_name += namesOffset;
           namesOffset = 0;
         }
-        mappings += this.encoder.encode(value);
+        const encodedVal = this.encoder.encode(value);
+        mappings += encodedVal;
+        this.nextFileSourceNeedsComma = !(endsWith(encodedVal, ',') || endsWith(encodedVal, ';'));
       }
 
       inputMappings = inputMappings.slice(match[0].length);
@@ -365,6 +378,7 @@ class SourceMap {
           // remaining mappings over and jump to the final encoder
           // state.
           mappings += inputMappings;
+          this.nextFileSourceNeedsComma = !(endsWith(inputMappings, ',') || endsWith(inputMappings, ';'));
           inputMappings = '';
           this.linesMapped = initialMappedLines + cacheHint.lines;
           this.encoder = cacheHint.encoder;
@@ -380,6 +394,7 @@ class SourceMap {
           decoder.resetColumn();
           this.linesMapped += lines + match[1].replace(/,/g, '').length;
           mappings += match[0];
+          this.nextFileSourceNeedsComma = !(endsWith(match[0], ',') || endsWith(match[0], ';'));
           inputMappings = inputMappings.slice(match[0].length);
         }
       }


### PR DESCRIPTION
I noticed while profiling that 20% of concatenating was being spent executing a
regex inside addFileSource, 60 seconds in my case.

I first tried changing the termination check to use indexOf, which a jsperf
highlighted as much faster than most line termination checks. I wasn't able to
find a great jsperf that compared all possible methods, nor did I check that
they were representative of this libs usage. I did however profile the result
and see ~4 seconds (~7%) come off.

I then looked for all the places that `this.content.mappings` was being
mutated/assigned to. Since this was a fairly limited set of lines, I moved the
termination check to the bits that were being appended, and then tracked
whether the new string was terminating with the correct character.

The result is that the original 60 seconds totally disappeared from my build.

This is basically a second attempt at this PR:
https://github.com/ef4/fast-sourcemap-concat/pull/48

Profiles (you can load these in Chrome's devTools under JavaScript Profiler:
[Archive.zip](https://github.com/ef4/fast-sourcemap-concat/files/1849046/Archive.zip)

fast-concat-with-test.cpuprofile: The original regex test version.
fast-concat-endsWith-indexOf.cpuprofile:  Replacing the regex test with indexOf checking.
fast-concat-track-commas.cpuprofile: Tracking whether the commas is needed.