### PR TITLE
downgrading source-map-url

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "memory-streams": "^0.1.3",
     "mkdirp": "^0.5.0",
     "source-map": "^0.4.2",
-    "source-map-url": "^0.4.0",
+    "source-map-url": "^0.3.0",
     "sourcemap-validator": "^1.1.0"
   },
   "devDependencies": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -1064,9 +1064,9 @@ slice-ansi@1.0.0:
   dependencies:
     is-fullwidth-code-point "^2.0.0"
 
-source-map-url@^0.4.0:
-  version "0.4.0"
-  resolved "https://registry.yarnpkg.com/source-map-url/-/source-map-url-0.4.0.tgz#3e935d7ddd73631b97659956d55128e87b5084a3"
+source-map-url@^0.3.0:
+  version "0.3.0"
+  resolved "https://registry.yarnpkg.com/source-map-url/-/source-map-url-0.3.0.tgz#7ecaf13b57bcd09da8a40c5d269db33799d4aaf9"
 
 source-map@^0.4.2:
   version "0.4.4"


### PR DESCRIPTION
Version 0.4.0 introduces a feature that tries to look for URLs in non-terminal position, but the regex is too broad and it can result in syntax errors.

The upstream package hasn't been touched in three years, and we've been relying on 0.3.0 for a long time, so I think it's safe to just go back to that.