### PR TITLE
Support custom path for concat stats

### DIFF
--- a/lib/source-map.js
+++ b/lib/source-map.js
@@ -432,7 +432,8 @@ class SourceMap {
         }
 
         if (process.env.CONCAT_STATS) {
-          let outputPath = process.cwd() + '/concat-stats-for/' + sourceMap.id + '-' + path.basename(sourceMap.outputFile) + '.json';
+          let concatStatsPath = process.env.CONCAT_STATS_PATH || `${process.cwd()}/concat-stats-for`;
+          let outputPath = path.join(concatStatsPath, `${sourceMap.id}-${path.basename(sourceMap.outputFile)}.json`);
 
           sourceMap.writeConcatStatsSync(
             outputPath,

--- a/test/test.js
+++ b/test/test.js
@@ -367,18 +367,18 @@ describe('fast sourcemap concat', function() {
 
     afterEach(function() {
       delete process.env.CONCAT_STATS;
+      delete process.env.CONCAT_STATS_PATH;
     });
-
-    it('correctly emits file for given concat', function() {
+    
+    let runEmitTest = (outputPath) => {
       concat.addFile('fixtures/inner/second.js');
       concat.addFile('fixtures/inner/first.js');
-
+  
       expect(outputs.length).to.eql(0);
-
+  
       return concat.end().then(function() {
         expect(outputs.length).to.eql(1);
-
-        let outputPath = process.cwd() + '/concat-stats-for/' + concat.id + '-' + path.basename(concat.outputFile) + '.json';
+  
         expect(outputs[0].outputPath).to.eql(outputPath);
         expect(outputs[0].content).to.eql({
           outputFile: concat.outputFile,
@@ -388,6 +388,16 @@ describe('fast sourcemap concat', function() {
           }
         });
       });
+    };
+
+    it('correctly emits file for given concat with default path', function() {
+      return runEmitTest(`${process.cwd()}/concat-stats-for/${concat.id}-${path.basename(concat.outputFile)}.json`);
+    });
+
+    it('correctly emits file for given concat with path from env', function() {
+      let statsPath = '/tmp/concat-stats-for';
+      process.env.CONCAT_STATS_PATH = statsPath;
+      return runEmitTest(`${statsPath}/${concat.id}-${path.basename(concat.outputFile)}.json`);
     });
 
     it('correctly DOES NOT emits file for given concat, if the flag is not set', function() {


### PR DESCRIPTION
Check CONCAT_STATS_PATH environment variable to support a custom path for concat stats files.
This is meant to support tighter integration between this lib and tools (addons) requiring that
stats data, so they can set a custom path (e.g. system temp) without "polluting" the user's current working dir.