### PR TITLE
Drop node 4,6,8 and add 10,12

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,4 @@
 language: node_js
 node_js:
-  - 4
-  - 6
-  - 8
-  - 9
+  - 10
+  - 12

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -4,8 +4,8 @@
 environment:
   MOCHA_REPORTER: "mocha-appveyor-reporter"
   matrix:
-    - nodejs_version: "4"
-    - nodejs_version: "6"
+    - nodejs_version: "10"
+    - nodejs_version: "12"
 
 branches:
   except:

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "main": "lib/index.js",
   "scripts": {
     "test": "mocha --inline-diffs",
-    "test:debug": "mocha --no-timeouts debug"
+    "test:debug": "mocha --no-timeouts --inspect"
   },
   "files": [
     "lib"
@@ -31,6 +31,6 @@
     "sinon": "^1.12.2"
   },
   "engines": {
-    "node": ">= 4"
+    "node": "10.* || >= 12.*"
   }
 }


### PR DESCRIPTION
* Dropping `node 4,6` as it is EOLed officially. `node 8` EOL is Jan 2020. 
* Adding `node 10, 12` (current LTS) versions
* Needs major version bump
 