### PR TITLE
ci: use GitHub Actions instead of TravisCI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,31 @@
+name: CI
+
+on:
+  push:
+    branches:
+      - main
+      - master
+  pull_request: {}
+
+concurrency:
+  group: ci-${{ github.head_ref || github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  test:
+    name: "Tests"
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        node: [ 10.x, 12.x, 14.x, 16.x, 18.x ]
+    steps:
+      - uses: actions/checkout@v3
+      - name: Install Node
+        uses: actions/setup-node@v3
+        with:
+          node-version: ${{ matrix.node }}
+          cache: yarn
+      - name: Install Dependencies
+        run: yarn install --frozen-lockfile
+      - name: Run Tests
+        run: yarn run test

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,0 @@
-language: node_js
-node_js:
-  - 10
-  - 12


### PR DESCRIPTION
Ye' ol' free [travis-ci.org](https://travis-ci.org/github/ef4/fast-sourcemap-concat/pull_requests) is read-only now, and it looks like this project isn't setup on its successor (https://travis-ci.com). This PR adds a basic config to run the tests in GitHub Actions instead.