### PR TITLE
Remove sourcemap validation

### DIFF
--- a/lib/source-map.js
+++ b/lib/source-map.js
@@ -9,7 +9,7 @@ const crypto = require('crypto');
 const chalk = require('chalk');
 const EOL = require('os').EOL;
 const endsWith = require('./endsWith');
-const validator = require('sourcemap-validator');
+// const validator = require('sourcemap-validator');
 const logger = require('heimdalljs-logger')('fast-sourcemap-concat:');
 
 
@@ -114,20 +114,23 @@ class SourceMap {
 
     let valid = true;
 
-    if (inputSrcMap) {
-      try {
-        // TODO: don't stringify here
-        validator(source, JSON.stringify(inputSrcMap));
-      } catch (e) {
-        logger.error(' invalid sourcemap for: %s', filename);
-        if (typeof e === 'object' && e !== null) {
-          logger.error('   error: ', e.message);
-        }
+    // Comment sourcemap validation due to new behavior in babel sourcemap generation.
+    // Validator issue is described here: https://github.com/ben-ng/sourcemap-validator/issues/17
+    // Breaking change babel PR: https://github.com/babel/babel/pull/15022
+    // if (inputSrcMap) {
+    //   try {
+    //     // TODO: don't stringify here
+    //     validator(source, JSON.stringify(inputSrcMap));
+    //   } catch (e) {
+    //     logger.error(' invalid sourcemap for: %s', filename);
+    //     if (typeof e === 'object' && e !== null) {
+    //       logger.error('   error: ', e.message);
+    //     }
 
-        // print
-        valid = false;
-      }
-    }
+    //     // print
+    //     valid = false;
+    //   }
+    // }
 
     if (inputSrcMap && valid) {
       let haveLines = countNewLines(source);


### PR DESCRIPTION
Comment sourcemap validation due to new behavior in babel sourcemap generation. Probably babel is stable and we don't need validation as it is.