### PR TITLE
feat: allow none as mapCommentType

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,8 @@ Type: `string`
 
 If `'line'` is specified, `sourceMappingURL` will be written in a single-line comment (`//`).
 
+If `'none'` is specified, no reference to the source map is included in the source file.
+
 If anything else truthy is specified, `sourceMappingURL` will be written in a block comment (`/* */`).
 
 If no value is given, or a falsey value is given, will default to `'line'`.

--- a/lib/source-map.js
+++ b/lib/source-map.js
@@ -460,10 +460,15 @@ class SourceMap {
           sourceMappingUrl = `${dataUrlPrelude}${base64Content}`;
         }
 
-        if (sourceMap.mapCommentType === 'line') {
-          stream.write('//# sourceMappingURL=' + sourceMappingUrl + '\n');
-        } else {
-          stream.write('/*# sourceMappingURL=' + sourceMappingUrl + ' */\n');
+        switch (sourceMap.mapCommentType) {
+          case 'line':
+            stream.write('//# sourceMappingURL=' + sourceMappingUrl + '\n');
+            break;
+          case 'none':
+            break;
+          default:
+            stream.write('/*# sourceMappingURL=' + sourceMappingUrl + ' */\n');
+            break;
         }
 
         if (sourceMap.mapFile) {

--- a/test/test.js
+++ b/test/test.js
@@ -224,6 +224,16 @@ describe('fast sourcemap concat', function() {
     });
   });
 
+  it("outputs no comments when 'mapCommentType' is 'none'", function() {
+    let FILE = 'tmp/mapcommenttype.css';
+    let s = new SourceMap({outputFile: FILE, mapCommentType: 'none'});
+    return s.end().then(function() {
+      let result = fs.readFileSync(FILE, 'utf-8');
+      let expected = "";
+      assert.equal(result, expected);
+    });
+  });
+
   it("should warn but tolerate broken sourcemap URL", function() {
     let s = new SourceMap({outputFile: 'tmp/with-broken-input-map.js', baseDir: path.join(__dirname, 'fixtures')});
     s._warn = sinon.spy();


### PR DESCRIPTION
Added option to leave out mapComment to prevent the sourcemaps to be linked. 
Useful in situations where you want the sourcemaps to be generated (e.g. for external tools like Bugsnag), but not applied so production code remains obfuscated. 
This would resolve issue https://github.com/ember-cli/ember-cli/issues/7873